### PR TITLE
Compile resources in subdirectories correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ compile_gresources(<output>
 - **SOURCE_DIR** ***resource_directory***
 
   The source directory where the resource files are. If not overridden, this
-  value is set to `CMAKE_SOURCE_DIR`.
+  value is set to `CMAKE_CURRENT_SOURCE_DIR`.
 
 - **COMPRESS_ALL**, **NO_COMPRESS_ALL**
 
@@ -181,15 +181,15 @@ compile_gresources(RESOURCE_FILE
 
 What does this snippet do? First it sets some resource files to pack into a
 resource file. They are located in the source directory passed to CMake at
-invocation (`CMAKE_SOURCE_DIR`).
+invocation (`CMAKE_CURENT_SOURCE_DIR`).
 After that we compile the resources. Means we generate a *.gresource.xml*-file
 (it's path is put inside the `XML_OUT` variable) automatically from our
 `RESOURCE_LIST` and create a custom command that compiles the generated
 *.gresource.xml*-file with the provided resources into a resource bundle. Since
 no specific output file is specified via **TARGET** the output file is placed
-into the `CMAKE_BINARY_DIR` with the name *resources.gresource*. The first
-argument `RESOURCE_FILE` is a variable that is filled with the output file name,
-so with *resources.gresource* inside the build directory. This variable is
+into the `CMAKE_CURENT_BINARY_DIR` with the name *resources.gresource*. The
+first argument `RESOURCE_FILE` is a variable that is filled with the output file
+name, so with *resources.gresource* inside the build directory. This variable is
 helpful to create makefile targets (or to process the output file differently).
 
 So here comes a full *CMakeLists.txt* that creates the resources from before.

--- a/macros/CompileGResources.cmake
+++ b/macros/CompileGResources.cmake
@@ -38,7 +38,7 @@ function(COMPILE_GRESOURCES output xml_out)
     #            relative file name in registered resources.
     # SOURCE_DIR Overrides the resources base directory to search for resources.
     #            Normally this is set to the source directory with that CMake
-    #            was invoked (CMAKE_SOURCE_DIR).
+    #            was invoked (CMAKE_CURRENT_SOURCE_DIR).
     # TARGET     Overrides the name of the output file/-s. Normally the output
     #            names from glib-compile-resources tool is taken.
     set(CG_ONEVALUEARGS TYPE PREFIX SOURCE_DIR TARGET)
@@ -47,8 +47,8 @@ function(COMPILE_GRESOURCES output xml_out)
     # RESOURCES The list of resource files. Whether absolute or relative path is
     #           equal, absolute paths are stripped down to relative ones. If the
     #           absolute path is not inside the given base directory SOURCE_DIR
-    #           or CMAKE_SOURCE_DIR (if SOURCE_DIR is not overriden), this
-    #           function aborts.
+    #           or CMAKE_CURRENT_SOURCE_DIR (if SOURCE_DIR is not overriden),
+    #           this function aborts.
     # OPTIONS   Extra command line options passed to glib-compile-resources.
     set(CG_MULTIVALUEARGS RESOURCES OPTIONS)
 
@@ -135,7 +135,7 @@ function(COMPILE_GRESOURCES output xml_out)
     endforeach()
 
     # Construct .gresource.xml path.
-    set(CG_XML_FILE_PATH "${CMAKE_BINARY_DIR}/.gresource.xml")
+    set(CG_XML_FILE_PATH "${CMAKE_CURRENT_BINARY_DIR}/.gresource.xml")
 
     # Generate gresources XML target.
     list(APPEND CG_CMAKE_SCRIPT_ARGS "-D")
@@ -181,19 +181,19 @@ function(COMPILE_GRESOURCES output xml_out)
                        COMMAND ${CMAKE_COMMAND}
                        ARGS ${CG_CMAKE_SCRIPT_ARGS}
                        DEPENDS ${CG_RESOURCES_DEPENDENCIES}
-                       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                        COMMENT ${CG_XML_CUSTOM_COMMAND_COMMENT})
 
     # Create target manually if not set (to make sure glib-compile-resources
     # doesn't change behaviour with it's naming standards).
     if (NOT CG_ARG_TARGET)
-        set(CG_ARG_TARGET "${CMAKE_BINARY_DIR}/resources")
+        set(CG_ARG_TARGET "${CMAKE_CURRENT_BINARY_DIR}/resources")
         set(CG_ARG_TARGET "${CG_ARG_TARGET}.${CG_TARGET_FILE_ENDING}")
     endif()
 
     # Create source directory automatically if not set.
     if (NOT CG_ARG_SOURCE_DIR)
-        set(CG_ARG_SOURCE_DIR "${CMAKE_SOURCE_DIR}")
+        set(CG_ARG_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
     endif()
 
     # Add compilation target for resources.

--- a/macros/GenerateGXML.cmake
+++ b/macros/GenerateGXML.cmake
@@ -26,8 +26,8 @@ function(GENERATE_GXML xml_path)
     # RESOURCES The list of resource files. Whether absolute or relative path is
     #           equal, absolute paths are stripped down to relative ones. If the
     #           absolute path is not inside the given base directory SOURCE_DIR
-    #           or CMAKE_SOURCE_DIR (if SOURCE_DIR is not overriden), this
-    #           function aborts.
+    #           or CMAKE_CURRENT_SOURCE_DIR (if SOURCE_DIR is not overriden),
+    #           this function aborts.
     set(GXML_MULTIVALUEARGS RESOURCES)
 
     # Parse the arguments.


### PR DESCRIPTION
Those changes allows this project to be in a subdirectory (with add_subdirectory) of main project that uses it.
