### PR TITLE
Respect SOURCE_DIR option for input resource files

### DIFF
--- a/macros/CompileGResources.cmake
+++ b/macros/CompileGResources.cmake
@@ -135,13 +135,18 @@ function(COMPILE_GRESOURCES output xml_out)
         message(FATAL_ERROR ${CG_ERRMSG})
     endif()
 
+    # If source directory is not set, default to working directory.
+    if (NOT CG_ARG_SOURCE_DIR)
+        set(CG_ARG_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+    endif()
+
     # Extract all dependencies for targets from resource list.
     foreach(res ${CG_ARG_RESOURCES})
         if (NOT(("${res}" STREQUAL "COMPRESS") OR
                 ("${res}" STREQUAL "STRIPBLANKS") OR
                 ("${res}" STREQUAL "TOPIXDATA")))
 
-            list(APPEND CG_RESOURCES_DEPENDENCIES "${res}")
+            list(APPEND CG_RESOURCES_DEPENDENCIES "${CG_ARG_SOURCE_DIR}/${res}")
         endif()
     endforeach()
 
@@ -200,11 +205,6 @@ function(COMPILE_GRESOURCES output xml_out)
     if (NOT CG_ARG_TARGET)
         set(CG_ARG_TARGET "${CMAKE_CURRENT_BINARY_DIR}/resources")
         set(CG_ARG_TARGET "${CG_ARG_TARGET}.${CG_TARGET_FILE_ENDING}")
-    endif()
-
-    # Create source directory automatically if not set.
-    if (NOT CG_ARG_SOURCE_DIR)
-        set(CG_ARG_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
     endif()
 
     # Add compilation target for resources.


### PR DESCRIPTION
It is actually respected and passed down to the glic-compile-resources
tool, however, the generated Makefiles won't find those resource files
because they are always assumed to be at CMAKE_CURRENT_SOURCE_DIR.

Fixes https://github.com/Makman2/GCR_CMake/issues/20

Takes over https://github.com/Makman2/GCR_CMake/pull/19.

Thank you @daleclack for the original submission!